### PR TITLE
Also run CI on Windows and Mac, not just Linux

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,11 +11,17 @@ env:
 
 jobs:
   test:
-
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        runs-on:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+    runs-on: ${{ matrix.runs-on }}
 
     steps:
     - uses: actions/checkout@v4
     - uses: Swatinem/rust-cache@v2
+    - uses: dtolnay/rust-toolchain@stable
     - name: Run tests
       run: cargo test --verbose


### PR DESCRIPTION
Now that #8 is adding a bit of platform-specific code, we really ought to expand CI coverage