### PR TITLE
Preserve Exif when writing JPEG and PNG

### DIFF
--- a/src/encoders/common.rs
+++ b/src/encoders/common.rs
@@ -1,0 +1,13 @@
+//! Helpers shared between all encoders
+
+use crate::image::Image;
+use image::ImageEncoder;
+
+pub fn write_icc_and_exif(encoder: &mut impl ImageEncoder, image: &Image) {
+    if let Some(icc) = image.icc.clone() {
+        let _ = encoder.set_icc_profile(icc); // ignore UnsupportedError
+    };
+    if let Some(exif) = image.exif.clone() {
+        let _ = encoder.set_exif_metadata(exif); // ignore UnsupportedError
+    };
+}

--- a/src/encoders/jpeg.rs
+++ b/src/encoders/jpeg.rs
@@ -1,8 +1,8 @@
 use std::io::Write;
 
 use image::codecs::jpeg::JpegEncoder;
-use image::ImageEncoder;
 
+use crate::encoders::common::write_icc_and_exif;
 use crate::{error::MagickError, image::Image, plan::Modifiers, wm_try};
 
 pub fn encode<W: Write>(
@@ -18,9 +18,7 @@ pub fn encode<W: Write>(
         None => 92, // imagemagick default
     };
     let mut encoder = JpegEncoder::new_with_quality(writer, quality);
-    if let Some(icc) = image.icc.clone() {
-        let _ = encoder.set_icc_profile(icc); // ignore UnsupportedError
-    };
+    write_icc_and_exif(&mut encoder, image);
     Ok(wm_try!(image.pixels.write_with_encoder(encoder)))
 }
 

--- a/src/encoders/mod.rs
+++ b/src/encoders/mod.rs
@@ -1,4 +1,5 @@
 pub mod avif;
+pub mod common;
 pub mod gif;
 pub mod jpeg;
 pub mod png;

--- a/src/encoders/png.rs
+++ b/src/encoders/png.rs
@@ -1,8 +1,8 @@
 use std::io::Write;
 
 use image::codecs::png::{CompressionType, FilterType, PngEncoder};
-use image::ImageEncoder;
 
+use crate::encoders::common::write_icc_and_exif;
 use crate::plan::Modifiers;
 use crate::wm_err;
 use crate::{error::MagickError, image::Image, wm_try};
@@ -14,9 +14,7 @@ pub fn encode<W: Write>(
 ) -> Result<(), MagickError> {
     let (compression, filter) = quality_to_compression_parameters(modifiers.quality)?;
     let mut encoder = PngEncoder::new_with_quality(writer, compression, filter);
-    if let Some(icc) = image.icc.clone() {
-        let _ = encoder.set_icc_profile(icc); // ignore UnsupportedError
-    };
+    write_icc_and_exif(&mut encoder, image);
     Ok(wm_try!(image.pixels.write_with_encoder(encoder)))
 }
 


### PR DESCRIPTION
Now that it's implemented in `image` we can add this to wondermagick.

The built-in WebP encoder in `image` also implements it but `webp` crate does not.