### PR TITLE
Reuse input format for output if we can't determine based on path

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -7,15 +7,26 @@ use crate::{error::MagickError, image::Image, wm_try};
 /// If the format has not been explicitly specified, guesses the format based on file contents.
 pub fn decode(file: &OsStr, format: Option<ImageFormat>) -> Result<Image, MagickError> {
     let mut reader = wm_try!(ImageReader::open(file));
-    match format {
-        Some(format) => reader.set_format(format),
-        None => reader = wm_try!(reader.with_guessed_format()),
-    }
+    let format = match format {
+        Some(format) => {
+            reader.set_format(format);
+            format
+        }
+        None => {
+            reader = wm_try!(reader.with_guessed_format());
+            reader.format().unwrap()
+        }
+    };
     let mut decoder = wm_try!(reader.into_decoder());
     let exif = decoder.exif_metadata().unwrap_or(None);
     let icc = decoder.icc_profile().unwrap_or(None);
     let pixels = wm_try!(DynamicImage::from_decoder(decoder));
-    Ok(Image { exif, icc, pixels })
+    Ok(Image {
+        format,
+        exif,
+        icc,
+        pixels,
+    })
 }
 
 // You know what would be a cool optimization for decoding process?

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -15,12 +15,11 @@ pub fn encode(
     // Wrap in BufWriter for performance
     let mut writer = BufWriter::new(file);
 
-    let format = if let Some(format) = format {
-        format
-    } else {
-        // TODO: instead of rejecting unknown format, reuse the input format as imagemagick does
-        wm_try!(ImageFormat::from_path(file_path))
-    };
+    // If format is unspecified, guess based on the output path;
+    // if that fails, use the input format (like ImageMagick)
+    let format = format
+        .or_else(|| ImageFormat::from_path(file_path).ok())
+        .unwrap_or(image.format);
 
     match format {
         // TODO: dedicated encoders for way more formats

--- a/src/image.rs
+++ b/src/image.rs
@@ -1,7 +1,8 @@
-use image::DynamicImage;
+use image::{DynamicImage, ImageFormat};
 
 #[derive(Debug, Clone)]
 pub struct Image {
+    pub format: ImageFormat,
     pub exif: Option<Vec<u8>>,
     pub icc: Option<Vec<u8>>,
     pub pixels: DynamicImage,


### PR DESCRIPTION
Currently wondermagick throws an error if the output format can't be determined. This makes it use the input format, just like ImageMagick.