### PR TITLE
More accurate detection of option-like arguments

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -60,9 +60,9 @@ pub fn parse_args(mut args: Vec<OsString>) -> Result<ExecutionPlan, MagickError>
     // the observed behavior on my system is that they're only ever parsed as flags.
     let output_filename = args.pop().unwrap();
     // imagemagick rejects output filenames that look like arguments
-    if starts_with_sign(&output_filename) {
+    if optionlike(&output_filename) {
         return Err(wm_err!(
-            "missing an image filename `{}'",
+            "missing output filename `{}'",
             output_filename.to_string_lossy()
         ));
     }
@@ -74,7 +74,7 @@ pub fn parse_args(mut args: Vec<OsString>) -> Result<ExecutionPlan, MagickError>
     while let Some(raw_arg) = iter.next() {
         if raw_arg.as_encoded_bytes() == [b'-'] {
             todo!(); // this is stdin or stdout
-        } else if starts_with_sign(&raw_arg) {
+        } else if optionlike(&raw_arg) {
             // A file named "-foobar.jpg" will be parsed as an option.
             // Sadly imagemagick does not support the -- convention to separate options and filenames,
             // and there is nothing we can do about it without introducing incompatibility in argument parsing.
@@ -90,13 +90,12 @@ pub fn parse_args(mut args: Vec<OsString>) -> Result<ExecutionPlan, MagickError>
     Ok(plan)
 }
 
-/// Checks if the string starts with a `-` or a `+`
-fn starts_with_sign(arg: &OsStr) -> bool {
-    let first_byte = arg.as_encoded_bytes().first();
-    first_byte == Some(&b'-')
-        || first_byte == Some(&b'+')
-    // Anything starting with two dashes instead of one is treated as filename
-    && arg.as_encoded_bytes().get(1) != Some(&b'-')
+/// Checks if the string starts with a `-` or a `+`, followed by an ASCII letter
+fn optionlike(arg: &OsStr) -> bool {
+    matches!(
+        arg.as_encoded_bytes(),
+        [b'-' | b'+', b'a'..=b'z' | b'A'..=b'Z', ..],
+    )
 }
 
 /// Splits the string into a sign (- or +) and argument name


### PR DESCRIPTION
Based on testing, it seems that ImageMagick treats an argument as an option if it starts with `-` or `+` followed by an ASCII letter. So `magick input.png -a.png` doesn't work ("missing output filename"), but if you replace the last argument with `-123.png` or `-á.png` it works because it's treated as a positional argument (the output filename).

This patch mimics this behaviour.