### PR TITLE
Fix decoding of plugin formats

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -10,11 +10,11 @@ pub fn decode(file: &OsStr, format: Option<ImageFormat>) -> Result<Image, Magick
     let format = match format {
         Some(format) => {
             reader.set_format(format);
-            format
+            Some(format)
         }
         None => {
             reader = wm_try!(reader.with_guessed_format());
-            reader.format().unwrap()
+            reader.format()
         }
     };
     let mut decoder = wm_try!(reader.into_decoder());

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -91,6 +91,7 @@ fn choose_encoding_format(
     } else if let Some(format) = image.format {
         Ok(format)
     } else {
+        // fallback to emptry string matches imagemagick
         let extension = Path::new(file_path).extension().unwrap_or(OsStr::new(""));
         Err(wm_err!(
             "no decode delegate for this image format `{}'",

--- a/src/image.rs
+++ b/src/image.rs
@@ -2,7 +2,9 @@ use image::{DynamicImage, ImageFormat};
 
 #[derive(Debug, Clone)]
 pub struct Image {
-    pub format: ImageFormat,
+    // TODO: ImageFormat only lists the built-in formats, which is why it's an Option.
+    // We need the extended format enum with a string for plug-in formats here, but it's not public (yet).
+    pub format: Option<ImageFormat>,
     pub exif: Option<Vec<u8>>,
     pub icc: Option<Vec<u8>>,
     pub pixels: DynamicImage,


### PR DESCRIPTION
https://github.com/Shnatsel/wondermagick/pull/21 added an assumption that the format being decoded is built into `image`, but now that it has a plugin interface that's not the case.

Fixes panics on decoding JPEG XL.