### PR TITLE
Fix dedicated encoders not being used with the default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ hardened_malloc = ["mimalloc/secure"]
 asm = ["image/nasm"]
 
 # Image format features - passed through to the `image` crate
-default-formats = ["image/default-formats", "jxl"]
+default-formats = ["avif", "bmp", "dds", "exr", "ff", "gif", "hdr", "ico", "jpeg", "png", "pnm", "qoi", "tga", "tiff", "webp"]
 avif = ["image/avif"]
 bmp = ["image/bmp"]
 dds = ["image/dds"]


### PR DESCRIPTION
In #29 I've overlooked the fact that features such as `png` are not enabled by default, so the dedicated PNG encoder is cfg'd out and never used in the default configuration. This PR fixes it.

cc @hanneskaeufler