### PR TITLE
Give `-composite` try with minimal changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,6 +320,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -396,6 +402,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "getrandom"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -446,6 +458,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -491,6 +509,16 @@ name = "imgref"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c5cedc30da3a610cac6b4ba17597bdf7152cf974e8aab3afb3d54455e371c8"
+
+[[package]]
+name = "indexmap"
+version = "2.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
 
 [[package]]
 name = "interpolate_name"
@@ -903,6 +931,28 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "parameterized"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "502433373749b48ce909bc70124593d055347640417cf88518bac794171bcef8"
+dependencies = [
+ "parameterized-macro",
+]
+
+[[package]]
+name = "parameterized-macro"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6510c182b2c8ab147c6ee557784009379f07dc1c388f2731603730a727c9b665"
+dependencies = [
+ "fnv",
+ "indexmap",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "paste"
@@ -1494,6 +1544,7 @@ dependencies = [
  "image",
  "jxl-oxide",
  "mimalloc",
+ "parameterized",
  "pic-scale-safe",
  "quickcheck",
  "quickcheck_macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ jxl = ["dep:jxl-oxide"]
 quickcheck = "1"
 quickcheck_macros = "1"
 derive-quickcheck-arbitrary = "0.1.3"
+parameterized = "2.1.0"
 
 # Most of the time is spent in `image` and its dependencies,
 # so build it with optimizations in debug mode to get good performance

--- a/src/arg_parsers/gravity.rs
+++ b/src/arg_parsers/gravity.rs
@@ -24,9 +24,10 @@ impl TryFrom<&OsStr> for Gravity {
                 return Ok(known_gravity);
             }
         }
-        Err(ArgParseErr {
-            message: Some(format!("unrecognized gravity `{}'", s.to_string_lossy())),
-        })
+        Err(ArgParseErr::with_msg(format!(
+            "unrecognized gravity `{}'",
+            s.to_string_lossy()
+        )))
     }
 }
 

--- a/src/arg_parsers/gravity.rs
+++ b/src/arg_parsers/gravity.rs
@@ -19,15 +19,9 @@ impl TryFrom<&OsStr> for Gravity {
     type Error = ArgParseErr;
 
     fn try_from(s: &OsStr) -> Result<Self, Self::Error> {
-        if let Some(s_utf8) = s.to_str() {
-            if let Ok(known_gravity) = Self::try_from(s_utf8) {
-                return Ok(known_gravity);
-            }
-        }
-        Err(ArgParseErr::with_msg(format!(
-            "unrecognized gravity `{}'",
-            s.to_string_lossy()
-        )))
+        s.to_str()
+            .ok_or_else(|| ArgParseErr::with_msg("non-utf8 gravity value"))
+            .and_then(|val| Gravity::try_from(val).map_err(ArgParseErr::with_msg))
     }
 }
 

--- a/src/arg_parsers/gravity.rs
+++ b/src/arg_parsers/gravity.rs
@@ -1,0 +1,69 @@
+use crate::arg_parse_err::ArgParseErr;
+use std::{ffi::OsStr, str::FromStr};
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Gravity {
+    NorthWest,
+    North,
+    NorthEast,
+    West,
+    Center,
+    East,
+    SouthWest,
+    South,
+    SouthEast,
+}
+
+impl FromStr for Gravity {
+    type Err = ArgParseErr;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::try_from(OsStr::new(s))
+    }
+}
+
+impl TryFrom<&OsStr> for Gravity {
+    type Error = ArgParseErr;
+
+    fn try_from(s: &OsStr) -> Result<Self, Self::Error> {
+        if s.is_empty() {
+            return Err(ArgParseErr::with_msg("gravity type must be non-empty"));
+        }
+
+        let string: &str = s
+            .try_into()
+            .map_err(|_e| ArgParseErr::with_msg("invalid gravity type"))?;
+
+        match string.to_lowercase().as_str() {
+            "center" => Ok(Gravity::Center),
+            "north" => Ok(Gravity::North),
+            "south" => Ok(Gravity::South),
+            "east" => Ok(Gravity::East),
+            "west" => Ok(Gravity::West),
+            "northeast" => Ok(Gravity::NorthEast),
+            "northwest" => Ok(Gravity::NorthWest),
+            "southeast" => Ok(Gravity::SouthEast),
+            "southwest" => Ok(Gravity::SouthWest),
+            _ => Err(ArgParseErr::with_msg("invalid gravity argument")),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Gravity;
+    use std::str::FromStr;
+
+    #[test]
+    fn test_case_insensitive() {
+        assert_eq!(Gravity::from_str("NorthWest"), Ok(Gravity::NorthWest));
+        assert_eq!(Gravity::from_str("northwest"), Ok(Gravity::NorthWest));
+    }
+
+    #[test]
+    fn test_invalid() {
+        assert!(Gravity::from_str("unknown").is_err());
+        assert!(Gravity::from_str("💥 non-ascii").is_err());
+        assert!(Gravity::from_str("").is_err());
+    }
+}

--- a/src/arg_parsers/gravity.rs
+++ b/src/arg_parsers/gravity.rs
@@ -1,6 +1,8 @@
 use crate::arg_parse_err::ArgParseErr;
 use std::ffi::OsStr;
 
+/// https://imagemagick.org/script/command-line-options.php#gravity
+/// Running ImageMagick 6's `convert -list gravity` shows all possible values.
 #[derive(Debug, Clone, PartialEq, strum::Display, strum::EnumString, strum::IntoStaticStr)]
 #[strum(ascii_case_insensitive)]
 pub enum Gravity {

--- a/src/arg_parsers/gravity.rs
+++ b/src/arg_parsers/gravity.rs
@@ -13,6 +13,8 @@ pub enum Gravity {
     SouthWest,
     South,
     SouthEast,
+    None,
+    Forget,
 }
 
 impl TryFrom<&OsStr> for Gravity {

--- a/src/arg_parsers/mod.rs
+++ b/src/arg_parsers/mod.rs
@@ -23,3 +23,5 @@ mod grayscale_method;
 pub use grayscale_method::*;
 mod unsharpen_geometry;
 pub use unsharpen_geometry::*;
+mod gravity;
+pub use gravity::*;

--- a/src/args.rs
+++ b/src/args.rs
@@ -50,6 +50,7 @@ impl SignedArg {
 #[strum(serialize_all = "kebab-case")]
 pub enum Arg {
     AutoOrient,
+    Composite,
     Crop,
     // TODO: -format can actually change meaning, as `-format type`
     // and as `-format expression`. We currently only implement `-format expression`.
@@ -76,6 +77,7 @@ impl Arg {
     pub fn needs_value(&self) -> bool {
         match self {
             Arg::AutoOrient => false,
+            Arg::Composite => false,
             Arg::Crop => true,
             Arg::Format => true,
             Arg::Filter => true,
@@ -100,6 +102,7 @@ impl Arg {
     pub fn help_text(&self) -> &'static str {
         match self {
             Arg::AutoOrient => "automagically orient (rotate) image",
+            Arg::Composite => "perform alpha composition on two images and an optional mask",
             Arg::Crop => "cut out a rectangular region of the image",
             Arg::Format => "output formatted image characteristics",
             Arg::Filter => "use this filter when resizing an image",

--- a/src/args.rs
+++ b/src/args.rs
@@ -60,6 +60,7 @@ pub enum Arg {
     Flop,
     Blur,
     GaussianBlur,
+    Gravity,
     Grayscale,
     Identify,
     Monochrome,
@@ -85,6 +86,7 @@ impl Arg {
             Arg::Flop => false,
             Arg::Blur => true,
             Arg::GaussianBlur => true,
+            Arg::Gravity => true,
             Arg::Grayscale => true,
             Arg::Identify => false,
             Arg::Monochrome => false,
@@ -110,6 +112,9 @@ impl Arg {
             Arg::Flop => "flop image horizontally",
             Arg::Blur => "reduce image noise and reduce detail levels",
             Arg::GaussianBlur => "reduce image noise and reduce detail levels",
+            Arg::Gravity => {
+                "sets the current gravity suggestion for various other settings and options"
+            }
             Arg::Grayscale => "convert image to grayscale",
             Arg::Identify => "identify the format and characteristics of the image",
             Arg::Monochrome => "transform image to black and white",

--- a/src/operations/composite.rs
+++ b/src/operations/composite.rs
@@ -33,10 +33,8 @@ fn offset_from_gravity(
         "Calculating offset for gravity {:?} with image1_dim {:?} and image2_dim {:?}",
         gravity, image1_dim, image2_dim
     );
-    let w1 = i64::from(image1_dim.0);
-    let h1 = i64::from(image1_dim.1);
-    let w2 = i64::from(image2_dim.0);
-    let h2 = i64::from(image2_dim.1);
+    let (w1, h1) = (i64::from(image1_dim.0), i64::from(image1_dim.1));
+    let (w2, h2) = (i64::from(image2_dim.0), i64::from(image2_dim.1));
 
     match gravity {
         Gravity::Center => ((w1 - w2) / 2, (h1 - h2) / 2),

--- a/src/operations/composite.rs
+++ b/src/operations/composite.rs
@@ -50,3 +50,44 @@ fn offset_from_gravity(
         Gravity::SouthWest => (0, image1_dim.1 - image2_dim.1),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::offset_from_gravity;
+    use super::Gravity;
+    use parameterized::parameterized;
+
+    const IMG1_DIM: (u32, u32) = (800, 600);
+    const IMG2_DIM: (u32, u32) = (200, 100);
+
+    #[parameterized(
+        gravity = {
+            Gravity::Center,
+            Gravity::North,
+            Gravity::South,
+            Gravity::East,
+            Gravity::West,
+            Gravity::NorthEast,
+            Gravity::NorthWest,
+            Gravity::SouthEast,
+            Gravity::SouthWest
+        },
+        expected_offsets = {
+            (300, 250),
+            (300, 0),
+            (300, 500),
+            (600, 250),
+            (0, 250),
+            (600, 0),
+            (0, 0),
+            (600, 500),
+            (0, 500)
+        }
+    )]
+    fn test_offset_from_gravity(gravity: Gravity, expected_offsets: (u32, u32)) {
+        assert_eq!(
+            offset_from_gravity(&gravity, IMG1_DIM, IMG2_DIM),
+            expected_offsets
+        );
+    }
+}

--- a/src/operations/composite.rs
+++ b/src/operations/composite.rs
@@ -1,0 +1,19 @@
+use crate::{
+    arg_parsers::{FileFormat, Location},
+    decode::decode,
+    error::MagickError,
+    image::Image,
+};
+use image::imageops::overlay;
+
+pub fn composite(
+    image1: &mut Image,
+    image2_location: &Location,
+    image2_format: Option<FileFormat>,
+    //TODO: If a third image is given this is treated as a grayscale blending 'mask' image
+    // relative to the first 'destination' image. This mask is blended with the source image.
+) -> Result<(), MagickError> {
+    let image2 = decode(image2_location, image2_format)?;
+    overlay(&mut image1.pixels, &image2.pixels, 0, 0);
+    Ok(())
+}

--- a/src/operations/composite.rs
+++ b/src/operations/composite.rs
@@ -20,7 +20,7 @@ pub fn composite(
     } else {
         (0, 0)
     };
-    overlay(&mut image1.pixels, &image2.pixels, x as i64, y as i64);
+    overlay(&mut image1.pixels, &image2.pixels, x, y);
     Ok(())
 }
 
@@ -28,26 +28,26 @@ fn offset_from_gravity(
     gravity: &Gravity,
     image1_dim: (u32, u32),
     image2_dim: (u32, u32),
-) -> (u32, u32) {
+) -> (i64, i64) {
+    eprintln!(
+        "Calculating offset for gravity {:?} with image1_dim {:?} and image2_dim {:?}",
+        gravity, image1_dim, image2_dim
+    );
+    let w1 = i64::from(image1_dim.0);
+    let h1 = i64::from(image1_dim.1);
+    let w2 = i64::from(image2_dim.0);
+    let h2 = i64::from(image2_dim.1);
+
     match gravity {
-        Gravity::Center => (
-            (image1_dim.0 - image2_dim.0) / 2,
-            (image1_dim.1 - image2_dim.1) / 2,
-        ),
-        Gravity::North => ((image1_dim.0 - image2_dim.0) / 2, 0),
-        Gravity::South => (
-            (image1_dim.0 - image2_dim.0) / 2,
-            image1_dim.1 - image2_dim.1,
-        ),
-        Gravity::East => (
-            image1_dim.0 - image2_dim.0,
-            (image1_dim.1 - image2_dim.1) / 2,
-        ),
-        Gravity::West => (0, (image1_dim.1 - image2_dim.1) / 2),
-        Gravity::NorthEast => (image1_dim.0 - image2_dim.0, 0),
+        Gravity::Center => ((w1 - w2) / 2, (h1 - h2) / 2),
+        Gravity::North => ((w1 - w2) / 2, 0),
+        Gravity::South => ((w1 - w2) / 2, h1 - h2),
+        Gravity::East => (w1 - w2, (h1 - h2) / 2),
+        Gravity::West => (0, (h1 - h2) / 2),
+        Gravity::NorthEast => (w1 - w2, 0),
         Gravity::NorthWest => (0, 0),
-        Gravity::SouthEast => (image1_dim.0 - image2_dim.0, image1_dim.1 - image2_dim.1),
-        Gravity::SouthWest => (0, image1_dim.1 - image2_dim.1),
+        Gravity::SouthEast => (w1 - w2, h1 - h2),
+        Gravity::SouthWest => (0, h1 - h2),
     }
 }
 
@@ -84,10 +84,18 @@ mod tests {
             (0, 500)
         }
     )]
-    fn test_offset_from_gravity(gravity: Gravity, expected_offsets: (u32, u32)) {
+    fn test_offset_from_gravity(gravity: Gravity, expected_offsets: (i64, i64)) {
         assert_eq!(
             offset_from_gravity(&gravity, IMG1_DIM, IMG2_DIM),
             expected_offsets
         );
+    }
+
+    #[test]
+    fn test_offset_from_gravity_img2_larger_than_img1() {
+        let img1_dim = (100, 100);
+        let img2_dim = (200, 200);
+        let offsets = offset_from_gravity(&Gravity::Center, img1_dim, img2_dim);
+        assert_eq!(offsets, (-50, -50));
     }
 }

--- a/src/operations/composite.rs
+++ b/src/operations/composite.rs
@@ -45,7 +45,7 @@ fn offset_from_gravity(
         Gravity::East => (w1 - w2, (h1 - h2) / 2),
         Gravity::West => (0, (h1 - h2) / 2),
         Gravity::NorthEast => (w1 - w2, 0),
-        Gravity::NorthWest => (0, 0),
+        Gravity::NorthWest | Gravity::Forget | Gravity::None => (0, 0),
         Gravity::SouthEast => (w1 - w2, h1 - h2),
         Gravity::SouthWest => (0, h1 - h2),
     }
@@ -69,6 +69,8 @@ mod tests {
             Gravity::West,
             Gravity::NorthEast,
             Gravity::NorthWest,
+            Gravity::None,
+            Gravity::Forget,
             Gravity::SouthEast,
             Gravity::SouthWest
         },
@@ -79,6 +81,8 @@ mod tests {
             (600, 250),
             (0, 250),
             (600, 0),
+            (0, 0),
+            (0, 0),
             (0, 0),
             (600, 500),
             (0, 500)

--- a/src/operations/composite.rs
+++ b/src/operations/composite.rs
@@ -10,13 +10,13 @@ pub fn composite(
     image1: &mut Image,
     image2_location: &Location,
     image2_format: Option<FileFormat>,
-    gravity: Option<&Gravity>,
+    gravity: Option<Gravity>,
     // TODO: If a third image is given this is treated as a grayscale blending 'mask' image
     // relative to the first 'destination' image. This mask is blended with the source image.
 ) -> Result<(), MagickError> {
     let image2 = decode(image2_location, image2_format)?;
     let (x, y) = if let Some(g) = gravity {
-        offset_from_gravity(g, image1.pixels.dimensions(), image2.pixels.dimensions())
+        offset_from_gravity(&g, image1.pixels.dimensions(), image2.pixels.dimensions())
     } else {
         (0, 0)
     };

--- a/src/operations/composite.rs
+++ b/src/operations/composite.rs
@@ -1,19 +1,52 @@
 use crate::{
-    arg_parsers::{FileFormat, Location},
+    arg_parsers::{FileFormat, Gravity, Location},
     decode::decode,
     error::MagickError,
     image::Image,
 };
-use image::imageops::overlay;
+use image::{imageops::overlay, GenericImageView};
 
 pub fn composite(
     image1: &mut Image,
     image2_location: &Location,
     image2_format: Option<FileFormat>,
-    //TODO: If a third image is given this is treated as a grayscale blending 'mask' image
+    gravity: Option<&Gravity>,
+    // TODO: If a third image is given this is treated as a grayscale blending 'mask' image
     // relative to the first 'destination' image. This mask is blended with the source image.
 ) -> Result<(), MagickError> {
     let image2 = decode(image2_location, image2_format)?;
-    overlay(&mut image1.pixels, &image2.pixels, 0, 0);
+    let (x, y) = if let Some(g) = gravity {
+        offset_from_gravity(g, image1.pixels.dimensions(), image2.pixels.dimensions())
+    } else {
+        (0, 0)
+    };
+    overlay(&mut image1.pixels, &image2.pixels, x as i64, y as i64);
     Ok(())
+}
+
+fn offset_from_gravity(
+    gravity: &Gravity,
+    image1_dim: (u32, u32),
+    image2_dim: (u32, u32),
+) -> (u32, u32) {
+    match gravity {
+        Gravity::Center => (
+            (image1_dim.0 - image2_dim.0) / 2,
+            (image1_dim.1 - image2_dim.1) / 2,
+        ),
+        Gravity::North => ((image1_dim.0 - image2_dim.0) / 2, 0),
+        Gravity::South => (
+            (image1_dim.0 - image2_dim.0) / 2,
+            image1_dim.1 - image2_dim.1,
+        ),
+        Gravity::East => (
+            image1_dim.0 - image2_dim.0,
+            (image1_dim.1 - image2_dim.1) / 2,
+        ),
+        Gravity::West => (0, (image1_dim.1 - image2_dim.1) / 2),
+        Gravity::NorthEast => (image1_dim.0 - image2_dim.0, 0),
+        Gravity::NorthWest => (0, 0),
+        Gravity::SouthEast => (image1_dim.0 - image2_dim.0, image1_dim.1 - image2_dim.1),
+        Gravity::SouthWest => (0, image1_dim.1 - image2_dim.1),
+    }
 }

--- a/src/operations/mod.rs
+++ b/src/operations/mod.rs
@@ -13,7 +13,7 @@ mod unsharpen;
 
 use crate::{
     arg_parsers::{
-        BlurGeometry, CropGeometry, FileFormat, Filter, GrayscaleMethod, IdentifyFormat,
+        BlurGeometry, CropGeometry, FileFormat, Filter, Gravity, GrayscaleMethod, IdentifyFormat,
         LoadCropGeometry, Location, ResizeGeometry, UnsharpenGeometry,
     },
     error::MagickError,
@@ -27,7 +27,7 @@ pub enum Operation {
     Thumbnail(ResizeGeometry, Option<Filter>),
     Scale(ResizeGeometry),
     Sample(ResizeGeometry),
-    Composite(Location, Option<FileFormat>),
+    Composite(Location, Option<FileFormat>, Option<Gravity>),
     CropOnLoad(LoadCropGeometry),
     Crop(CropGeometry),
     Identify(Option<IdentifyFormat>),
@@ -48,8 +48,8 @@ impl Operation {
             Operation::Thumbnail(geom, filter) => resize::thumbnail(image, geom, *filter),
             Operation::Scale(geom) => resize::scale(image, geom),
             Operation::Sample(geom) => resize::sample(image, geom),
-            Operation::Composite(other_image, other_image_format) => {
-                composite::composite(image, &other_image, *other_image_format)
+            Operation::Composite(other_image, other_image_format, gravity) => {
+                composite::composite(image, &other_image, *other_image_format, gravity.as_ref())
             }
             Operation::CropOnLoad(geom) => crop::crop_on_load(image, geom),
             Operation::Crop(geom) => crop::crop(image, geom),
@@ -75,7 +75,7 @@ impl Operation {
             Thumbnail(resize_geometry, _) => *self = Thumbnail(*resize_geometry, mods.filter),
             Scale(_) => (),
             Sample(_) => (),
-            Composite(_, _) => (),
+            Composite(_, _, _) => (),
             CropOnLoad(_) => (),
             Crop(_) => (),
             Identify(_) => *self = Identify(mods.identify_format.clone()),

--- a/src/operations/mod.rs
+++ b/src/operations/mod.rs
@@ -49,7 +49,7 @@ impl Operation {
             Operation::Scale(geom) => resize::scale(image, geom),
             Operation::Sample(geom) => resize::sample(image, geom),
             Operation::Composite(other_image, other_image_format, gravity) => {
-                composite::composite(image, &other_image, *other_image_format, gravity.clone())
+                composite::composite(image, other_image, *other_image_format, gravity.clone())
             }
             Operation::CropOnLoad(geom) => crop::crop_on_load(image, geom),
             Operation::Crop(geom) => crop::crop(image, geom),

--- a/src/operations/mod.rs
+++ b/src/operations/mod.rs
@@ -49,7 +49,7 @@ impl Operation {
             Operation::Scale(geom) => resize::scale(image, geom),
             Operation::Sample(geom) => resize::sample(image, geom),
             Operation::Composite(other_image, other_image_format, gravity) => {
-                composite::composite(image, &other_image, *other_image_format, gravity.as_ref())
+                composite::composite(image, &other_image, *other_image_format, gravity.clone())
             }
             Operation::CropOnLoad(geom) => crop::crop_on_load(image, geom),
             Operation::Crop(geom) => crop::crop(image, geom),

--- a/src/operations/mod.rs
+++ b/src/operations/mod.rs
@@ -1,5 +1,6 @@
 mod auto_orient;
 mod blur;
+mod composite;
 mod crop;
 mod flip;
 pub use flip::Axis;
@@ -12,8 +13,8 @@ mod unsharpen;
 
 use crate::{
     arg_parsers::{
-        BlurGeometry, CropGeometry, Filter, GrayscaleMethod, IdentifyFormat, LoadCropGeometry,
-        ResizeGeometry, UnsharpenGeometry,
+        BlurGeometry, CropGeometry, FileFormat, Filter, GrayscaleMethod, IdentifyFormat,
+        LoadCropGeometry, Location, ResizeGeometry, UnsharpenGeometry,
     },
     error::MagickError,
     image::Image,
@@ -26,6 +27,7 @@ pub enum Operation {
     Thumbnail(ResizeGeometry, Option<Filter>),
     Scale(ResizeGeometry),
     Sample(ResizeGeometry),
+    Composite(Location, Option<FileFormat>),
     CropOnLoad(LoadCropGeometry),
     Crop(CropGeometry),
     Identify(Option<IdentifyFormat>),
@@ -46,6 +48,9 @@ impl Operation {
             Operation::Thumbnail(geom, filter) => resize::thumbnail(image, geom, *filter),
             Operation::Scale(geom) => resize::scale(image, geom),
             Operation::Sample(geom) => resize::sample(image, geom),
+            Operation::Composite(other_image, other_image_format) => {
+                composite::composite(image, &other_image, *other_image_format)
+            }
             Operation::CropOnLoad(geom) => crop::crop_on_load(image, geom),
             Operation::Crop(geom) => crop::crop(image, geom),
             Operation::Identify(format) => identify::identify(image, format.clone()),
@@ -70,6 +75,7 @@ impl Operation {
             Thumbnail(resize_geometry, _) => *self = Thumbnail(*resize_geometry, mods.filter),
             Scale(_) => (),
             Sample(_) => (),
+            Composite(_, _) => (),
             CropOnLoad(_) => (),
             Crop(_) => (),
             Identify(_) => *self = Identify(mods.identify_format.clone()),

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -4,8 +4,8 @@ use std::{
 };
 
 use crate::arg_parsers::{
-    parse_numeric_arg, BlurGeometry, CropGeometry, FileFormat, GrayscaleMethod, IdentifyFormat,
-    InputFileArg, Location, ResizeGeometry, UnsharpenGeometry,
+    parse_numeric_arg, BlurGeometry, CropGeometry, FileFormat, Gravity, GrayscaleMethod,
+    IdentifyFormat, InputFileArg, Location, ResizeGeometry, UnsharpenGeometry,
 };
 use crate::args::{Arg, SignedArg};
 use crate::decode::decode;
@@ -63,6 +63,7 @@ impl ExecutionPlan {
                 self.add_operation(Operation::Composite(
                     image_to_comp.location,
                     image_to_comp.format,
+                    self.modifiers.gravity.clone(),
                 ))
             }
             Arg::Crop => {
@@ -77,6 +78,7 @@ impl ExecutionPlan {
             Arg::GaussianBlur => self.add_operation(Operation::GaussianBlur(
                 BlurGeometry::try_from(value.unwrap())?,
             )),
+            Arg::Gravity => self.modifiers.gravity = Some(Gravity::try_from(value.unwrap())?),
             Arg::Grayscale => self.add_operation(Operation::Grayscale(GrayscaleMethod::try_from(
                 value.unwrap(),
             )?)),
@@ -232,6 +234,7 @@ pub struct Modifiers {
     pub strip: Strip,
     pub identify_format: Option<IdentifyFormat>,
     pub filter: Option<Filter>,
+    pub gravity: Option<Gravity>,
 }
 
 #[derive(Debug, Default, Copy, Clone)] // bools default to false

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -55,6 +55,16 @@ impl ExecutionPlan {
     ) -> Result<(), ArgParseErr> {
         match signed_arg.arg {
             Arg::AutoOrient => self.add_operation(Operation::AutoOrient),
+            Arg::Composite => {
+                let image_to_comp = self
+                    .input_files
+                    .pop()
+                    .ok_or(ArgParseErr::with_msg("image sequence is required"))?;
+                self.add_operation(Operation::Composite(
+                    image_to_comp.location,
+                    image_to_comp.format,
+                ))
+            }
             Arg::Crop => {
                 self.add_operation(Operation::Crop(CropGeometry::try_from(value.unwrap())?))
             }

--- a/tests/wm_convert_integration_tests.rs
+++ b/tests/wm_convert_integration_tests.rs
@@ -1,10 +1,15 @@
 use std::fs;
 use std::process::Command;
 
-#[test]
-fn test_convert_png_to_jpg_succeeds() {
+fn setup<'a>() -> (&'a str, &'a str) {
     let binary = env!("CARGO_BIN_EXE_wm-convert");
     let tmp_dir = env!("CARGO_TARGET_TMPDIR");
+    (binary, tmp_dir)
+}
+
+#[test]
+fn test_convert_png_to_jpg_succeeds() {
+    let (binary, tmp_dir) = setup();
     let output_path = format!("{}/resized.jpg", tmp_dir);
     let _ = fs::remove_file(&output_path);
 
@@ -19,8 +24,7 @@ fn test_convert_png_to_jpg_succeeds() {
 
 #[test]
 fn test_convert_composite_succeeds() {
-    let binary = env!("CARGO_BIN_EXE_wm-convert");
-    let tmp_dir = env!("CARGO_TARGET_TMPDIR");
+    let (binary, tmp_dir) = setup();
     let output_path = format!("{}/composited.png", tmp_dir);
     let _ = fs::remove_file(&output_path);
 
@@ -40,8 +44,7 @@ fn test_convert_composite_succeeds() {
 
 #[test]
 fn test_resize_identify_succeeds() {
-    let binary = env!("CARGO_BIN_EXE_wm-convert");
-    let tmp_dir = env!("CARGO_TARGET_TMPDIR");
+    let (binary, tmp_dir) = setup();
     let output_path = format!("{}/resized.png", tmp_dir);
     let _ = fs::remove_file(&output_path);
 

--- a/tests/wm_convert_integration_tests.rs
+++ b/tests/wm_convert_integration_tests.rs
@@ -18,6 +18,27 @@ fn test_convert_png_to_jpg_succeeds() {
 }
 
 #[test]
+fn test_convert_composite_succeeds() {
+    let binary = env!("CARGO_BIN_EXE_wm-convert");
+    let tmp_dir = env!("CARGO_TARGET_TMPDIR");
+    let output_path = format!("{}/composited.png", tmp_dir);
+    let _ = fs::remove_file(&output_path);
+
+    let result = Command::new(binary)
+        .args(&[
+            "./tests/sample.png",
+            "./tests/sample.png",
+            "-composite",
+            &output_path,
+        ])
+        .output()
+        .expect("convert did not exit successfully");
+
+    assert!(result.status.success());
+    assert!(std::path::Path::new(&output_path).exists());
+}
+
+#[test]
 fn test_resize_identify_succeeds() {
     let binary = env!("CARGO_BIN_EXE_wm-convert");
     let tmp_dir = env!("CARGO_TARGET_TMPDIR");


### PR DESCRIPTION
Doesn't look ideal yet, but it actually already is doable to wire it in with the given `plan` structure.

```
$ cargo run -- ~/Downloads/a/Planeton.png ~/Downloads/a/gallerymagic-128.png -composite ~/Downloads/foo-wonder.png
```

<img width="1024" height="1024" alt="foo-magick" src="https://github.com/user-attachments/assets/0ec720ed-8173-4e3d-99a0-13fbd8c994d5" />

```
$ magick ~/Downloads/a/Planeton.png ~/Downloads/a/gallerymagic-128.png -composite ~/Downloads/foo-magick.png
```

<img width="1024" height="1024" alt="foo-magick" src="https://github.com/user-attachments/assets/f19f44c5-3a3d-46c9-83d1-42bae8c1b26c" />
