### PR TITLE
Add `-sepia-tone threshold` support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1584,6 +1584,7 @@ dependencies = [
  "image",
  "image-extras",
  "mimalloc",
+ "num-traits",
  "pic-scale-safe",
  "quickcheck",
  "quickcheck_macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/Shnatsel/wondermagick"
 current_platform = "0.2.0"
 bytemuck = "1"
 image = { version = "0.25.9", default-features = false, features = ["rayon"] }
+num-traits = "0.2"
 pic-scale-safe = { version = "0.1.5", features = ["rayon"] }
 strum = { version = "0.26.3", features = ["derive"] }
 tempfile = "3.23.0"

--- a/src/arg_parsers/mod.rs
+++ b/src/arg_parsers/mod.rs
@@ -21,3 +21,5 @@ mod blur_geometry;
 pub use blur_geometry::*;
 mod grayscale_method;
 pub use grayscale_method::*;
+mod sepia_threshold;
+pub use sepia_threshold::*;

--- a/src/arg_parsers/mod.rs
+++ b/src/arg_parsers/mod.rs
@@ -25,3 +25,5 @@ mod grayscale_method;
 pub use grayscale_method::*;
 mod unsharpen_geometry;
 pub use unsharpen_geometry::*;
+mod sepia_threshold;
+pub use sepia_threshold::*;

--- a/src/arg_parsers/sepia_threshold.rs
+++ b/src/arg_parsers/sepia_threshold.rs
@@ -2,7 +2,7 @@ use crate::arg_parse_err::ArgParseErr;
 use std::{ffi::OsStr, str::FromStr};
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct SepiaThreshold(f32);
+pub struct SepiaThreshold(pub f32);
 
 impl FromStr for SepiaThreshold {
     type Err = ArgParseErr;

--- a/src/arg_parsers/sepia_threshold.rs
+++ b/src/arg_parsers/sepia_threshold.rs
@@ -1,0 +1,65 @@
+use crate::arg_parse_err::ArgParseErr;
+use std::{ffi::OsStr, str::FromStr};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct SepiaThreshold(f32);
+
+impl FromStr for SepiaThreshold {
+    type Err = ArgParseErr;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::try_from(OsStr::new(s))
+    }
+}
+
+impl TryFrom<&OsStr> for SepiaThreshold {
+    type Error = ArgParseErr;
+
+    fn try_from(s: &OsStr) -> Result<Self, Self::Error> {
+        match s.to_str() {
+            None => Err(ArgParseErr::with_msg("non-utf8 sepia threshold value")),
+            Some(s) => {
+                if s.ends_with("%") && s.len() > 1 {
+                    s[0..(s.len() - 1)]
+                        .parse::<f32>()
+                        .map_err(|_| ArgParseErr::with_msg("invalid sepia threshold format"))
+                        .map(|v| SepiaThreshold(v / 100.0))
+                } else {
+                    s.parse::<f32>()
+                        .map_err(|_| ArgParseErr::with_msg("invalid sepia threshold format"))
+                        .map(SepiaThreshold)
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SepiaThreshold;
+    use std::str::FromStr;
+
+    #[test]
+    fn test_percentages() {
+        assert_eq!(SepiaThreshold::from_str("80%"), Ok(SepiaThreshold(0.8)));
+        assert_eq!(SepiaThreshold::from_str("5%"), Ok(SepiaThreshold(0.05)));
+        assert_eq!(SepiaThreshold::from_str("05%"), Ok(SepiaThreshold(0.05)));
+        assert_eq!(
+            SepiaThreshold::from_str("99.9999%"),
+            Ok(SepiaThreshold(0.999999))
+        );
+    }
+
+    #[test]
+    fn test_floats() {
+        assert_eq!(SepiaThreshold::from_str("0.8"), Ok(SepiaThreshold(0.8)));
+        assert_eq!(SepiaThreshold::from_str("100.8"), Ok(SepiaThreshold(100.8)));
+    }
+
+    #[test]
+    fn test_invalid() {
+        assert!(SepiaThreshold::from_str("0.8%%").is_err());
+        assert!(SepiaThreshold::from_str("%").is_err());
+        assert!(SepiaThreshold::from_str("abc%").is_err());
+    }
+}

--- a/src/args.rs
+++ b/src/args.rs
@@ -67,6 +67,7 @@ pub enum Arg {
     Resize,
     Sample,
     Scale,
+    SepiaTone,
     Strip,
     Thumbnail,
 }
@@ -89,6 +90,7 @@ impl Arg {
             Arg::Quality => true,
             Arg::Resize => true,
             Arg::Sample => true,
+            Arg::SepiaTone => true,
             Arg::Scale => true,
             Arg::Strip => false,
             Arg::Thumbnail => true,
@@ -112,6 +114,7 @@ impl Arg {
             Arg::Quality => "JPEG/MIFF/PNG compression level", // I'm so sorry
             Arg::Resize => "resize the image",
             Arg::Sample => "scale image with pixel sampling",
+            Arg::SepiaTone => "simulate a sepia-toned photo",
             Arg::Scale => "scale the image",
             Arg::Strip => "strip image of all profiles and comments",
             Arg::Thumbnail => "create a thumbnail of the image",

--- a/src/args.rs
+++ b/src/args.rs
@@ -69,6 +69,7 @@ pub enum Arg {
     Resize,
     Sample,
     Scale,
+    SepiaTone,
     Strip,
     Thumbnail,
     Unsharp,
@@ -95,6 +96,7 @@ impl Arg {
             Arg::Quality => true,
             Arg::Resize => true,
             Arg::Sample => true,
+            Arg::SepiaTone => true,
             Arg::Scale => true,
             Arg::Strip => false,
             Arg::Thumbnail => true,
@@ -122,6 +124,7 @@ impl Arg {
             Arg::Quality => "JPEG/MIFF/PNG compression level", // I'm so sorry
             Arg::Resize => "resize the image",
             Arg::Sample => "scale image with pixel sampling",
+            Arg::SepiaTone => "simulate a sepia-toned photo",
             Arg::Scale => "scale the image",
             Arg::Strip => "strip image of all profiles and comments",
             Arg::Thumbnail => "create a thumbnail of the image",

--- a/src/operations/mod.rs
+++ b/src/operations/mod.rs
@@ -8,11 +8,12 @@ mod identify;
 mod monochrome;
 mod negate;
 mod resize;
+mod sepia_tone;
 
 use crate::{
     arg_parsers::{
         BlurGeometry, CropGeometry, Filter, GrayscaleMethod, IdentifyFormat, LoadCropGeometry,
-        ResizeGeometry,
+        ResizeGeometry, SepiaThreshold,
     },
     error::MagickError,
     image::Image,
@@ -35,6 +36,7 @@ pub enum Operation {
     Grayscale(GrayscaleMethod),
     Flip(Axis),
     Monochrome,
+    SepiaTone(SepiaThreshold),
 }
 
 impl Operation {
@@ -54,6 +56,7 @@ impl Operation {
             Operation::Grayscale(method) => grayscale::grayscale(image, method),
             Operation::Flip(axis) => flip::flip(image, axis),
             Operation::Monochrome => monochrome::monochrome(image),
+            Operation::SepiaTone(threshold) => sepia_tone::sepia_tone(image, threshold),
         }
     }
 
@@ -77,6 +80,7 @@ impl Operation {
             Grayscale(_) => (),
             Flip(_) => (),
             Monochrome => (),
+            SepiaTone(_) => (),
         }
     }
 }

--- a/src/operations/mod.rs
+++ b/src/operations/mod.rs
@@ -9,12 +9,13 @@ mod identify;
 mod monochrome;
 mod negate;
 mod resize;
+mod sepia_tone;
 mod unsharpen;
 
 use crate::{
     arg_parsers::{
         BlurGeometry, CropGeometry, Filter, GrayscaleMethod, IdentifyFormat, LoadCropGeometry,
-        ResizeGeometry, UnsharpenGeometry,
+        ResizeGeometry, SepiaThreshold, UnsharpenGeometry,
     },
     error::MagickError,
     image::Image,
@@ -38,6 +39,7 @@ pub enum Operation {
     Flip(Axis),
     Monochrome,
     Unsharpen(UnsharpenGeometry),
+    SepiaTone(SepiaThreshold),
 }
 
 impl Operation {
@@ -58,6 +60,7 @@ impl Operation {
             Operation::Flip(axis) => flip::flip(image, axis),
             Operation::Monochrome => monochrome::monochrome(image),
             Operation::Unsharpen(geom) => unsharpen::unsharpen(image, geom),
+            Operation::SepiaTone(threshold) => sepia_tone::sepia_tone(image, threshold),
         }
     }
 
@@ -82,6 +85,7 @@ impl Operation {
             Flip(_) => (),
             Monochrome => (),
             Unsharpen(_) => (),
+            SepiaTone(_) => (),
         }
     }
 }

--- a/src/operations/sepia_tone.rs
+++ b/src/operations/sepia_tone.rs
@@ -1,0 +1,6 @@
+use crate::{arg_parsers::SepiaThreshold, error::MagickError, image::Image};
+
+pub fn sepia_tone(image: &mut Image, threshold: &SepiaThreshold) -> Result<(), MagickError> {
+    todo!();
+    Ok(())
+}

--- a/src/operations/sepia_tone.rs
+++ b/src/operations/sepia_tone.rs
@@ -1,6 +1,18 @@
 use crate::{arg_parsers::SepiaThreshold, error::MagickError, image::Image};
 
-pub fn sepia_tone(image: &mut Image, threshold: &SepiaThreshold) -> Result<(), MagickError> {
-    todo!();
+pub fn sepia_tone(image: &mut Image, _threshold: &SepiaThreshold) -> Result<(), MagickError> {
+    let mut rbga8 = image.pixels.to_rgba8();
+    for pixel in rbga8.pixels_mut() {
+        let r = pixel[0] as f32;
+        let g = pixel[1] as f32;
+        let b = pixel[2] as f32;
+
+        // German wikipedia shows coefficients for digital sepia toning.
+        // https://de.wikipedia.org/wiki/Sepia_(Fotografie)
+        pixel[0] = (0.393 * r + 0.769 * g + 0.189 * b).min(255.0) as u8;
+        pixel[1] = (0.349 * r + 0.686 * g + 0.168 * b).min(255.0) as u8;
+        pixel[2] = (0.272 * r + 0.534 * g + 0.131 * b).min(255.0) as u8;
+    }
+    image.pixels = image::DynamicImage::ImageRgba8(rbga8);
     Ok(())
 }

--- a/src/operations/sepia_tone.rs
+++ b/src/operations/sepia_tone.rs
@@ -1,18 +1,18 @@
 use crate::{arg_parsers::SepiaThreshold, error::MagickError, image::Image};
 
 pub fn sepia_tone(image: &mut Image, _threshold: &SepiaThreshold) -> Result<(), MagickError> {
-    let mut rbga8 = image.pixels.to_rgba8();
-    for pixel in rbga8.pixels_mut() {
-        let r = pixel[0] as f32;
-        let g = pixel[1] as f32;
-        let b = pixel[2] as f32;
+    let mut rbga = image.pixels.to_rgba32f();
+    for pixel in rbga.pixels_mut() {
+        let r = pixel[0];
+        let g = pixel[1];
+        let b = pixel[2];
 
         // German wikipedia shows coefficients for digital sepia toning.
         // https://de.wikipedia.org/wiki/Sepia_(Fotografie)
-        pixel[0] = (0.393 * r + 0.769 * g + 0.189 * b).min(255.0) as u8;
-        pixel[1] = (0.349 * r + 0.686 * g + 0.168 * b).min(255.0) as u8;
-        pixel[2] = (0.272 * r + 0.534 * g + 0.131 * b).min(255.0) as u8;
+        pixel[0] = (0.393 * r + 0.769 * g + 0.189 * b).min(255.0);
+        pixel[1] = (0.349 * r + 0.686 * g + 0.168 * b).min(255.0);
+        pixel[2] = (0.272 * r + 0.534 * g + 0.131 * b).min(255.0);
     }
-    image.pixels = image::DynamicImage::ImageRgba8(rbga8);
+    image.pixels = image::DynamicImage::ImageRgba32F(rbga);
     Ok(())
 }

--- a/src/operations/sepia_tone.rs
+++ b/src/operations/sepia_tone.rs
@@ -1,18 +1,58 @@
-use crate::{arg_parsers::SepiaThreshold, error::MagickError, image::Image};
+use image::{DynamicImage, ImageBuffer, Pixel, Primitive};
+use num_traits::NumCast;
+use std::fmt::Debug;
 
-pub fn sepia_tone(image: &mut Image, _threshold: &SepiaThreshold) -> Result<(), MagickError> {
-    let mut rbga = image.pixels.to_rgba32f();
-    for pixel in rbga.pixels_mut() {
-        let r = pixel[0];
-        let g = pixel[1];
-        let b = pixel[2];
+use crate::{arg_parsers::SepiaThreshold, error::MagickError, image::Image, wm_err};
 
-        // German wikipedia shows coefficients for digital sepia toning.
-        // https://de.wikipedia.org/wiki/Sepia_(Fotografie)
-        pixel[0] = (0.393 * r + 0.769 * g + 0.189 * b).min(255.0);
-        pixel[1] = (0.349 * r + 0.686 * g + 0.168 * b).min(255.0);
-        pixel[2] = (0.272 * r + 0.534 * g + 0.131 * b).min(255.0);
+pub fn sepia_tone(image: &mut Image, threshold: &SepiaThreshold) -> Result<(), MagickError> {
+    match &mut image.pixels {
+        DynamicImage::ImageLuma8(pixels) => sepia_tone_inner(pixels, threshold),
+        DynamicImage::ImageLumaA8(pixels) => sepia_tone_inner(pixels, threshold),
+        DynamicImage::ImageRgb8(pixels) => sepia_tone_inner(pixels, threshold),
+        DynamicImage::ImageRgba8(pixels) => sepia_tone_inner(pixels, threshold),
+        DynamicImage::ImageLuma16(pixels) => sepia_tone_inner(pixels, threshold),
+        DynamicImage::ImageLumaA16(pixels) => sepia_tone_inner(pixels, threshold),
+        DynamicImage::ImageRgb16(pixels) => sepia_tone_inner(pixels, threshold),
+        DynamicImage::ImageRgba16(pixels) => sepia_tone_inner(pixels, threshold),
+        DynamicImage::ImageRgb32F(pixels) => sepia_tone_inner(pixels, threshold),
+        DynamicImage::ImageRgba32F(pixels) => sepia_tone_inner(pixels, threshold),
+        _ => unreachable!(),
     }
-    image.pixels = image::DynamicImage::ImageRgba32F(rbga);
+}
+
+fn sepia_tone_inner<P, Container>(
+    buffer: &mut ImageBuffer<P, Container>,
+    _threshold: &SepiaThreshold,
+) -> Result<(), MagickError>
+where
+    P: Pixel + Debug,
+    P::Subpixel: Primitive + Debug,
+    Container: std::ops::DerefMut<Target = [P::Subpixel]>,
+{
+    if P::CHANNEL_COUNT < 3 {
+        return Ok(());
+    }
+
+    let max_val: f32 = NumCast::from(P::Subpixel::DEFAULT_MAX_VALUE).unwrap();
+
+    for pixel in buffer.pixels_mut() {
+        let (r, g, b): (f32, f32, f32) = {
+            let c = pixel.channels();
+            (
+                NumCast::from(c[0]).ok_or(wm_err!("foo"))?,
+                NumCast::from(c[1]).ok_or(wm_err!("bar"))?,
+                NumCast::from(c[2]).ok_or(wm_err!("baz"))?,
+            )
+        };
+
+        let new_r = (0.393 * r + 0.769 * g + 0.189 * b).clamp(0.0, max_val);
+        let new_g = (0.349 * r + 0.686 * g + 0.168 * b).clamp(0.0, max_val);
+        let new_b = (0.272 * r + 0.534 * g + 0.131 * b).clamp(0.0, max_val);
+
+        let c = pixel.channels_mut();
+        c[0] = NumCast::from(new_r).ok_or(wm_err!("foo"))?;
+        c[1] = NumCast::from(new_g).ok_or(wm_err!("bar"))?;
+        c[2] = NumCast::from(new_b).ok_or(wm_err!("baz"))?;
+    }
     Ok(())
 }

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -5,7 +5,7 @@ use std::{
 
 use crate::arg_parsers::{
     parse_numeric_arg, BlurGeometry, CropGeometry, FileFormat, GrayscaleMethod, IdentifyFormat,
-    InputFileArg, Location, ResizeGeometry,
+    InputFileArg, Location, ResizeGeometry, SepiaThreshold,
 };
 use crate::args::{Arg, SignedArg};
 use crate::decode::decode;
@@ -103,6 +103,9 @@ impl ExecutionPlan {
             Arg::Filter => self.modifiers.filter = Some(Filter::try_from(value.unwrap())?),
             Arg::Flip => self.add_operation(Operation::Flip(Axis::Vertical)),
             Arg::Flop => self.add_operation(Operation::Flip(Axis::Horizontal)),
+            Arg::SepiaTone => self.add_operation(Operation::SepiaTone(SepiaThreshold::try_from(
+                value.unwrap(),
+            )?)),
         };
 
         Ok(())

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -6,7 +6,7 @@ use std::{
 use crate::arg_parsers::{
     parse_numeric_arg, BlurGeometry, ChannelFormat, ColorModel, Colorspace, CropGeometry,
     FileFormat, GrayscaleMethod, IdentifyFormat, InputFileArg, Location, ResizeGeometry,
-    UnsharpenGeometry,
+    SepiaThreshold, UnsharpenGeometry,
 };
 use crate::args::{Arg, ArgParseCtx, ArgSign, SignedArg};
 use crate::decode::decode;
@@ -214,6 +214,9 @@ impl ExecutionPlan {
             Arg::Write => {
                 self.add_output(value.unwrap(), ctx)?;
             }
+            Arg::SepiaTone => self.add_operation(Operation::SepiaTone(SepiaThreshold::try_from(
+                value.unwrap(),
+            )?)),
         };
 
         Ok(())


### PR DESCRIPTION
Once more, the IM interface is very weird. The CLI accepts `50%` as well as `5`, so the percent sign is optional, but the results wildly differ.

> Specify threshold as the percent threshold of the intensity (0 - 99.9%).
This option applies a special effect to the image, similar to the effect achieved in a photo darkroom by sepia toning. Threshold ranges from 0 to QuantumRange and is a measure of the extent of the sepia toning. A threshold of 80% is a good starting point for a reasonable tone.

Based on this description, I'm also pretty sure the actual computation is probably completely different from what wikipedia suggests.

For `80%`, examples:

**Wondermagick**
![pexels-pixabay-247600-wm](https://github.com/user-attachments/assets/601c054b-abbf-425b-9f11-901a0113b626)

**ImageMagick**
![pexels-pixabay-247600-im](https://github.com/user-attachments/assets/11cfe2e9-105d-48af-beae-b0830892f626)

**Original**
![pexels-pixabay-247600](https://github.com/user-attachments/assets/9da6e0c8-635d-40aa-aa4e-36adbe9002c4)





