### PR TITLE
Add a `-write` option

### DIFF
--- a/tests/wm_convert_integration_tests.rs
+++ b/tests/wm_convert_integration_tests.rs
@@ -86,6 +86,45 @@ fn combine_succeeds() {
 }
 
 #[test]
+fn test_write_as_intermediate() {
+    let _guard = LOCK.lock().unwrap();
+
+    let binary = env!("CARGO_BIN_EXE_wm-convert");
+    let tmp_dir = env!("CARGO_TARGET_TMPDIR");
+
+    let output_path = format!("{}/resized.jpg", tmp_dir);
+    let copy_path = format!("{}/copy.png", tmp_dir);
+    let _ = fs::remove_file(&output_path);
+    let _ = fs::remove_file(&copy_path);
+
+    let write = Command::new(binary)
+        .args(&[
+            "./tests/sample.png",
+            "-write",
+            &copy_path,
+            "-resize",
+            "50%x50%",
+            &output_path,
+        ])
+        .output()
+        .expect("convert did not exit successfully");
+
+    assert!(write.status.success());
+    assert!(std::path::Path::new(&output_path).exists());
+    assert!(std::path::Path::new(&copy_path).exists());
+
+    let copy_img = image::open(&copy_path).unwrap();
+    let output_img = image::open(&output_path).unwrap();
+
+    use image::GenericImageView as _;
+    assert_ne!(
+        copy_img.dimensions(),
+        output_img.dimensions(),
+        "Intermediate write should have twice the dimensions of the final output",
+    );
+}
+
+#[test]
 fn combine_upgrades_to_rgba() {
     let _guard = LOCK.lock().unwrap();
 


### PR DESCRIPTION
Due to the filepath processing this was more complex than it seems at first. I think we'd want to eat the complexity of a new `ArgParseCtx` type now rather than later (see commit message). The testing is an integration test.

This is stacked on #76 since it only becomes possible with proper sequence support.

I'm refusing the temptation to extend `imagemagick` with this PR but if we'd want to provide use of `ExecutionPlan` as a library or even do unit testing then a special `Location` that writes to a pool of images could also be neat. We should also have the capabilities for output into `null:-` (which does not write at all) and `fd:1` as explained in [STDIN, STDOUT, and file descriptors](https://imagemagick.org/script/command-line-processing.php#input).

Feel free to review at your own pace if you want to prioritize operations.