### PR TITLE
prevent panic in read_float

### DIFF
--- a/src/arg_parsers/geometry.rs
+++ b/src/arg_parsers/geometry.rs
@@ -160,8 +160,16 @@ fn read_float(input: &mut &[u8], allow_sign: bool) -> Option<f64> {
         count += count_leading_digits(&input[count..]);
     }
 
+    if count == 0 {
+        return None;
+    }
+
     let (number, remainder) = input.split_at(count);
-    let float = str::from_utf8(number).unwrap().parse::<f64>().unwrap();
+
+    // str::from_utf8(number).ok()?  -> returns None if bytes aren't valid UTF-8
+    // .parse::<f64>().ok()?         -> returns None if string isn't a valid f64 (e.g. "." or "+")
+    let float = str::from_utf8(number).ok()?.parse::<f64>().ok()?;
+
     *input = remainder;
     Some(float)
 }


### PR DESCRIPTION
before
```
$ RUST_BACKTRACE=1 wm-convert m.png -resize -quality 100 x.wm.webp

thread 'main' (1227030) panicked at src/arg_parsers/geometry.rs:164:64:
called `Result::unwrap()` on an `Err` value: ParseFloatError { kind: Invalid }
stack backtrace:
   0: __rustc::rust_begin_unwind
   1: core::panicking::panic_fmt
   2: core::result::unwrap_failed
   3: wondermagick::arg_parsers::geometry::read_float
   4: <wondermagick::arg_parsers::geometry::Geometry as core::convert::TryFrom<&std::ffi::os_str::OsStr>>::try_from
   5: <wondermagick::arg_parsers::geometry_ext::ExtGeometry as core::convert::TryFrom<&std::ffi::os_str::OsStr>>::try_from
   6: <wondermagick::arg_parsers::resize::ResizeGeometry as core::convert::TryFrom<&std::ffi::os_str::OsStr>>::try_from
   7: wondermagick::plan::ExecutionPlan::apply_arg
   8: wondermagick::args::parse_args
   9: wm_convert::main
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
Aborted (core dumped)
```

after
```
wondermagick: invalid argument for option `resize': -quality @ src/plan.rs/{{closure}}/94.
```
