### PR TITLE
Make monochrome dithering configurable at runtime

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -90,7 +90,7 @@ impl Arg {
             Arg::GaussianBlur => true,
             Arg::Grayscale => true,
             Arg::Identify => false,
-            Arg::Monochrome => false,
+            Arg::Monochrome => true,
             Arg::Negate => false,
             Arg::Quality => true,
             Arg::Resize => true,
@@ -117,7 +117,7 @@ impl Arg {
             Arg::GaussianBlur => "reduce image noise and reduce detail levels",
             Arg::Grayscale => "convert image to grayscale",
             Arg::Identify => "identify the format and characteristics of the image",
-            Arg::Monochrome => "transform image to black and white",
+            Arg::Monochrome => "transform image to black and white (use 'default' or noise,shadow,highlight,brightness,contrast,gamma)",
             Arg::Negate => "replace every pixel with its complementary color",
             Arg::Quality => "JPEG/MIFF/PNG compression level", // I'm so sorry
             Arg::Resize => "resize the image",

--- a/src/operations/mod.rs
+++ b/src/operations/mod.rs
@@ -7,6 +7,7 @@ pub use flip::Axis;
 mod grayscale;
 mod identify;
 mod monochrome;
+pub use monochrome::MonochromeConfig;
 mod negate;
 mod resize;
 mod unsharpen;
@@ -36,7 +37,7 @@ pub enum Operation {
     GaussianBlur(BlurGeometry),
     Grayscale(GrayscaleMethod),
     Flip(Axis),
-    Monochrome,
+    Monochrome(MonochromeConfig),
     Unsharpen(UnsharpenGeometry),
 }
 
@@ -56,7 +57,7 @@ impl Operation {
             Operation::GaussianBlur(geom) => blur::gaussian_blur(image, geom),
             Operation::Grayscale(method) => grayscale::grayscale(image, method),
             Operation::Flip(axis) => flip::flip(image, axis),
-            Operation::Monochrome => monochrome::monochrome(image),
+            Operation::Monochrome(config) => monochrome::monochrome(image, config),
             Operation::Unsharpen(geom) => unsharpen::unsharpen(image, geom),
         }
     }
@@ -80,7 +81,7 @@ impl Operation {
             GaussianBlur(_) => (),
             Grayscale(_) => (),
             Flip(_) => (),
-            Monochrome => (),
+            Monochrome(_) => (),
             Unsharpen(_) => (),
         }
     }

--- a/src/operations/monochrome.rs
+++ b/src/operations/monochrome.rs
@@ -1,40 +1,185 @@
-use crate::{error::MagickError, image::Image};
+use crate::{arg_parse_err::ArgParseErr, error::MagickError, image::Image};
 use image::{DynamicImage, GrayImage, Luma};
 
-// Diffusion dampening for error that pushes dark pixels toward white.
-// At 1.0 full error propagates (ImageMagick 6 Floyd-Steinberg behavior).
-// Lower values suppress dithering in shadows, producing solid black areas.
-const SHADOW_DIFFUSION: f32 = 1.0;
+/// Runtime configuration for the monochrome dithering operator.
+/// All fields can be set from the command line or left at defaults.
+#[derive(Debug, Clone, PartialEq)]
+pub struct MonochromeConfig {
+    // Scales how much the blue noise texture shifts the black/white
+    // decision point per pixel.
+    //   0.0: No noise — clean mathematical dither bands
+    //  20.0 to 60.0: Subtle breakup of banding artifacts
+    //  80.0 to 140.0: Film-grain sweet spot (default 100)
+    // 150.0 to 255.0: Heavy noise, coarse texture
+    pub dither_noise: f32,
 
-// Diffusion dampening for error that pushes bright pixels toward black.
-// At 1.0 full error propagates (ImageMagick 6 Floyd-Steinberg behavior).
-// Lower values suppress dithering in highlights, producing solid white areas.
-const HIGHLIGHT_DIFFUSION: f32 = 1.0;
+    // Controls how far below the dark centroid the dither band extends.
+    // 0.0 = dither starts exactly at the dark centroid (IM6 default, hard black threshold)
+    // 0.5 = extends halfway from the dark centroid toward pure black
+    // 1.0 = extends all the way to pure black (maximum shadow graduation)
+    pub dither_band_shadow_expansion: f32,
 
-//   0.0: Pure Math (No Jitter)
-//  20.0 to 60.0: Subtle Breakup
-//  80.0 to 140.0: The "Film Grain" Sweet Spot
-// 150.0 to 255.0: Heavy Noise
-const THRESHOLD_JITTER: f32 = 100.0;
+    // Controls how far above the light centroid the dither band extends.
+    // 0.0 = dither ends exactly at the light centroid (IM6 default, hard white threshold)
+    // 0.5 = extends halfway from the light centroid toward pure white
+    // 1.0 = extends all the way to pure white (maximum highlight graduation)
+    pub dither_band_highlight_expansion: f32,
 
-// Controls how far below the dark centroid the dither band extends.
-// 0.0 = dither starts exactly at the dark centroid (IM6 default, hard black threshold)
-// 0.5 = extends halfway from the dark centroid toward pure black
-// 1.0 = extends all the way to pure black (maximum shadow graduation)
-const DITHER_BAND_SHADOW_EXPANSION: f32 = 0.0;
+    // Pre-dither brightness adjustment, applied to the grayscale image.
+    // Additive shift scaled to the 0–255 range.
+    // Range: -100.0 to 100.0 (0.0 = no change)
+    // Positive values lighten the image, negative values darken it.
+    pub brightness: f32,
 
-// Controls how far above the light centroid the dither band extends.
-// 0.0 = dither ends exactly at the light centroid (IM6 default, hard white threshold)
-// 0.5 = extends halfway from the light centroid toward pure white
-// 1.0 = extends all the way to pure white (maximum highlight graduation)
-const DITHER_BAND_HIGHLIGHT_EXPANSION: f32 = 0.0;
+    // Pre-dither contrast adjustment, applied to the grayscale image.
+    // Multiplicative scale around the midpoint
+    // Range: -100.0 to 100.0 (0.0 = no change)
+    // Positive values increase contrast (expand away from midpoint),
+    // negative values decrease it (compress toward midpoint).
+    pub contrast: f32,
 
-pub fn monochrome(image: &mut Image) -> Result<(), MagickError> {
+    // Pre-dither gamma adjustment, applied to the grayscale image.
+    // Power curve on normalized pixel values.
+    // Range: -100.0 to 100.0 (0.0 = no change)
+    // Negative values brighten midtones (gamma < 1), positive darken them (gamma > 1).
+    pub gamma: f32,
+}
+
+impl Default for MonochromeConfig {
+    fn default() -> Self {
+        Self {
+            dither_noise: 100.0,
+            dither_band_shadow_expansion: 0.0,
+            dither_band_highlight_expansion: 0.0,
+            brightness: 0.0,
+            contrast: 0.0,
+            gamma: 0.0,
+        }
+    }
+}
+
+impl MonochromeConfig {
+    /// Parse from a comma-separated string of six floats, or the literal "default".
+    /// Format: "dither_noise,shadow_expansion,highlight_expansion,brightness,contrast,gamma"
+    /// Example: "100,0,0.5,10,-5,0" or "default"
+    pub fn parse_arg(s: &str) -> Result<Self, ArgParseErr> {
+        let s = s.trim();
+        if s.eq_ignore_ascii_case("default") {
+            return Ok(Self::default());
+        }
+
+        let parts: Vec<&str> = s.split(',').collect();
+        if parts.len() != 6 {
+            return Err(ArgParseErr::with_msg(
+                "monochrome requires 'default' or exactly 6 comma-separated values: \
+                 noise,shadow_expansion,highlight_expansion,brightness,contrast,gamma",
+            ));
+        }
+
+        let parse = |i: usize, name: &str| -> Result<f32, ArgParseErr> {
+            parts[i]
+                .trim()
+                .parse::<f32>()
+                .map_err(|_| ArgParseErr::with_msg(format_args!("invalid {name} value")))
+        };
+
+        let range = |val: f32, lo: f32, hi: f32, name: &str| -> Result<f32, ArgParseErr> {
+            if val < lo || val > hi {
+                Err(ArgParseErr::with_msg(format_args!(
+                    "{name} must be between {lo} and {hi}, got {val}"
+                )))
+            } else {
+                Ok(val)
+            }
+        };
+
+        let dither_noise = range(parse(0, "dither_noise")?, 0.0, 255.0, "dither_noise")?;
+        let dither_band_shadow_expansion = range(
+            parse(1, "dither_band_shadow_expansion")?,
+            0.0,
+            1.0,
+            "dither_band_shadow_expansion",
+        )?;
+        let dither_band_highlight_expansion = range(
+            parse(2, "dither_band_highlight_expansion")?,
+            0.0,
+            1.0,
+            "dither_band_highlight_expansion",
+        )?;
+        let brightness = range(parse(3, "brightness")?, -100.0, 100.0, "brightness")?;
+        let contrast = range(parse(4, "contrast")?, -100.0, 100.0, "contrast")?;
+        let gamma = range(parse(5, "gamma")?, -100.0, 100.0, "gamma")?;
+
+        Ok(Self {
+            dither_noise,
+            dither_band_shadow_expansion,
+            dither_band_highlight_expansion,
+            brightness,
+            contrast,
+            gamma,
+        })
+    }
+}
+
+pub fn monochrome(image: &mut Image, config: &MonochromeConfig) -> Result<(), MagickError> {
     let mut grayscaled = image.pixels.to_luma8();
-    remap_to_dither_band(&mut grayscaled);
-    apply_blue_noise_scatter(&mut grayscaled);
+    adjust_colors(&mut grayscaled, config);
+    remap_to_dither_band(&mut grayscaled, config);
+    apply_blue_noise_scatter(&mut grayscaled, config);
     image.pixels = DynamicImage::ImageLuma8(grayscaled);
     Ok(())
+}
+
+/// Apply brightness, contrast, and gamma adjustments to a grayscale image.
+///
+/// Follows the gmic `adjust_colors` conventions:
+///  1. Brightness: additive shift (percentage of full range)
+///  2. Contrast: multiplicative scale around the midpoint
+///  3. Gamma: power-law curve on normalized values
+///
+/// All three parameters use a -100..100 range with 0 meaning no change.
+/// Order of operations matches gmic: brightness → contrast → gamma.
+fn adjust_colors(image: &mut GrayImage, config: &MonochromeConfig) {
+    if config.brightness == 0.0 && config.contrast == 0.0 && config.gamma == 0.0 {
+        return;
+    }
+
+    // Contrast factor: map -100..100 to a multiplier.
+    // At 0 → 1.0 (no change), at 100 → ~3.0, at -100 → ~0.0
+    let contrast_factor = ((config.contrast + 100.0) / 100.0).powi(2);
+
+    // Gamma exponent: map -100..100 to a power value.
+    // At 0 → 1.0 (no change), negative → <1 (brighten midtones),
+    // positive → >1 (darken midtones)
+    let gamma_exp = if config.gamma == 0.0 {
+        1.0
+    } else {
+        // Map -100..100 → exponent range ~0.1..10.0 via power of 10
+        // gmic uses: gamma_val = 10^(gamma_pct / 100)
+        // so -100 → 0.1 (strong brighten), 0 → 1.0, 100 → 10.0 (strong darken)
+        10.0_f32.powf(config.gamma / 100.0)
+    };
+
+    // Brightness offset: map -100..100 to -255..255
+    let brightness_offset = config.brightness * 255.0 / 100.0;
+
+    for pixel in image.pixels_mut() {
+        let mut v = pixel.0[0] as f32;
+
+        // 1. Brightness: additive shift
+        v += brightness_offset;
+
+        // 2. Contrast: scale around midpoint (127.5)
+        v = 127.5 + (v - 127.5) * contrast_factor;
+
+        // 3. Gamma: power curve on normalized value
+        if gamma_exp != 1.0 {
+            let normalized = (v / 255.0).clamp(0.0, 1.0);
+            v = normalized.powf(gamma_exp) * 255.0;
+        }
+
+        pixel.0[0] = v.clamp(0.0, 255.0) as u8;
+    }
 }
 
 /// Two-color quantization matching ImageMagick 6's `-monochrome` behavior.
@@ -45,12 +190,12 @@ pub fn monochrome(image: &mut Image) -> Result<(), MagickError> {
 /// are hard-thresholded to black, pixels brighter than the light centroid
 /// are hard-thresholded to white, and only the tones in between get dithered.
 ///
-/// The DITHER_BAND_SHADOW_EXPANSION and DITHER_BAND_HIGHLIGHT_EXPANSION
-/// constants let you widen the dither range beyond the centroids.
+/// The dither_band_shadow_expansion and dither_band_highlight_expansion
+/// fields let you widen the dither range beyond the centroids.
 /// At 0.0 you get the IM6-like hard threshold at the extremes.
 /// At 1.0 the dither band reaches all the way to 0 or 255, giving
 /// full graduation in shadows or highlights respectively.
-fn remap_to_dither_band(image: &mut GrayImage) {
+fn remap_to_dither_band(image: &mut GrayImage, config: &MonochromeConfig) {
     // Build histogram
     let mut histogram = [0u32; 256];
     for pixel in image.pixels() {
@@ -63,8 +208,8 @@ fn remap_to_dither_band(image: &mut GrayImage) {
     // Expand the dither band beyond the centroids based on tuning constants.
     // shadow_expansion=0 → band starts at c_dark, =1 → band starts at 0
     // highlight_expansion=0 → band ends at c_light, =1 → band ends at 255
-    let band_low = c_dark - (c_dark * DITHER_BAND_SHADOW_EXPANSION);
-    let band_high = c_light + ((255.0 - c_light) * DITHER_BAND_HIGHLIGHT_EXPANSION);
+    let band_low = c_dark - (c_dark * config.dither_band_shadow_expansion);
+    let band_high = c_light + ((255.0 - c_light) * config.dither_band_highlight_expansion);
 
     // Remap: values at or below band_low → 0, at or above band_high → 255,
     // values in between are linearly interpolated across 0..=255.
@@ -153,7 +298,7 @@ fn percentile_from_histogram(histogram: &[u32; 256], total: u64, percentile: f32
     255.0
 }
 
-pub fn apply_blue_noise_scatter(image: &mut GrayImage) {
+pub fn apply_blue_noise_scatter(image: &mut GrayImage, config: &MonochromeConfig) {
     let width = image.width();
     let height = image.height();
 
@@ -177,7 +322,8 @@ pub fn apply_blue_noise_scatter(image: &mut GrayImage) {
             let attenuation = 1.0 - (distance_from_center / 127.5).clamp(0.0, 1.0);
 
             // Modulate the threshold
-            let dynamic_threshold = 127.5 + (noise * THRESHOLD_JITTER * attenuation);
+            let dynamic_threshold =
+                127.5 + (noise * config.dither_noise * attenuation);
 
             // Thresholding
             let (new_val, color) = if current_val > dynamic_threshold {
@@ -190,20 +336,13 @@ pub fn apply_blue_noise_scatter(image: &mut GrayImage) {
             // Calculate raw error
             let raw_error = current_val - new_val;
 
-            // Apply asymmetric damping
-            let tuned_error = if raw_error > 0.0 {
-                raw_error * SHADOW_DIFFUSION
-            } else {
-                raw_error * HIGHLIGHT_DIFFUSION
-            };
-
             // Tight Sierra Lite distribution
             if x < width - 1 {
-                errors[idx + 1] += tuned_error * 0.5; // Right
+                errors[idx + 1] += raw_error * 0.5; // Right
             }
             if y < height - 1 {
-                errors[idx + (width + 2) as usize - 1] += tuned_error * 0.25; // Bottom-Left
-                errors[idx + (width + 2) as usize] += tuned_error * 0.25; // Bottom
+                errors[idx + (width + 2) as usize - 1] += raw_error * 0.25; // Bottom-Left
+                errors[idx + (width + 2) as usize] += raw_error * 0.25; // Bottom
             }
         }
     }

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -17,7 +17,7 @@ use crate::{encode, wm_err};
 use crate::{
     error::MagickError,
     operations::Axis,
-    operations::{Operation, RewriteOperation},
+    operations::{MonochromeConfig, Operation, RewriteOperation},
     wm_try,
 };
 
@@ -175,7 +175,13 @@ impl ExecutionPlan {
             Arg::Grayscale => self.add_operation(Operation::Grayscale(GrayscaleMethod::try_from(
                 value.unwrap(),
             )?)),
-            Arg::Monochrome => self.add_operation(Operation::Monochrome),
+            Arg::Monochrome => {
+                let val_str = value.unwrap().to_str().ok_or_else(|| {
+                    ArgParseErr::with_msg("monochrome: value is not valid UTF-8")
+                })?;
+                let config = MonochromeConfig::parse_arg(val_str)?;
+                self.add_operation(Operation::Monochrome(config));
+            }
             Arg::Negate => self.add_operation(Operation::Negate),
             Arg::Quality => self.modifiers.quality = Some(parse_numeric_arg(value.unwrap())?),
             Arg::Resize => self.add_operation(Operation::Resize(


### PR DESCRIPTION
Convert monochrome operator from hardcoded constants to a runtime-configurable MonochromeConfig struct, matching the existing pattern used by BlurGeometry, ResizeGeometry, etc.

New: MonochromeConfig struct with 6 tunable parameters

    dither_noise (0–255): Controls blue noise texture influence on the
        black/white threshold. 0 = clean mathematical bands, 100 = film-grain
        default, 255 = heavy noise.
    dither_band_shadow_expansion (0.0–1.0): How far below the dark
        centroid the dither band extends. 0 = IM6 hard black threshold,
        1 = full shadow graduation.
    dither_band_highlight_expansion (0.0–1.0): How far above the light centroid
        the dither band extends. 0 = IM6 hard white threshold, 1 = full highlight graduation.
    brightness (-100–100): Pre-dither additive brightness shift (gmic adjust_colors convention).
    contrast (-100–100): Pre-dither multiplicative contrast around midpoint.
    gamma (-100–100): Pre-dither power-law gamma curve.

CLI usage

-monochrome now requires a value:

-monochrome default
-monochrome 100,0,0,0,0,0        # equivalent to default
-monochrome 60,0.5,0.3,10,-5,0   # custom tuning

Removed

SHADOW_DIFFUSION / HIGHLIGHT_DIFFUSION constants: Redundant now that dither band expansion and brightness/contrast/gamma provide the same control with better ergonomics.

Breaking change

-monochrome now requires an argument. Use "-monochrome default" for previous behavior.