### PR TITLE
Fix PNG failing to encode f32 input data

### DIFF
--- a/src/encoders/png.rs
+++ b/src/encoders/png.rs
@@ -1,6 +1,8 @@
+use std::borrow::Cow;
 use std::io::Write;
 
 use image::codecs::png::{CompressionType, FilterType, PngEncoder};
+use image::DynamicImage;
 
 use crate::encoders::common::{optimize_pixel_format_and_precision, write_icc_and_exif};
 use crate::plan::Modifiers;
@@ -15,7 +17,9 @@ pub fn encode<W: Write>(
     let (compression, filter) = quality_to_compression_parameters(modifiers.quality)?;
     let mut encoder = PngEncoder::new_with_quality(writer, compression, filter);
     write_icc_and_exif(&mut encoder, image);
-    let pixels_to_write = optimize_pixel_format_and_precision(&image.pixels);
+    // we need to coerce f32 to u16 ourselves here before it goes through pixel format optimization
+    let pixels = coerce_pixel_format(&image.pixels);
+    let pixels_to_write = optimize_pixel_format_and_precision(&pixels);
     wm_try!(pixels_to_write.write_with_encoder(encoder));
     Ok(())
 }
@@ -61,5 +65,15 @@ fn quality_to_compression_parameters(
     } else {
         // default is 75 as per https://legacy.imagemagick.org/script/command-line-options.php#quality
         Ok((CompressionType::Level(7), FilterType::Adaptive))
+    }
+}
+
+/// Coerces f32 pixel data to u16, returns an unchanged DynamicImage otherwise
+fn coerce_pixel_format(image: &DynamicImage) -> Cow<'_, DynamicImage> {
+    use DynamicImage::*;
+    match image {
+        ImageRgb32F(_) => Cow::Owned(ImageRgb16(image.to_rgb16())),
+        ImageRgba32F(_) => Cow::Owned(ImageRgba16(image.to_rgba16())),
+        _ => Cow::Borrowed(image), // no-op
     }
 }


### PR DESCRIPTION
This is actually an upstream bug: https://github.com/image-rs/image/issues/2787

But we need special handling here regardless and that works around it on our side.