### PR TITLE
Port from webp crate to webpx crate for WebP encoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,6 +287,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "enough"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8e1bd41ecce82c300d0c84fa35b080fa6db50a5398b18f1abf0357bb067549e"
+
+[[package]]
 name = "env_filter"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -810,12 +816,13 @@ dependencies = [
 
 [[package]]
 name = "libwebp-sys"
-version = "0.9.6"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54cd30df7c7165ce74a456e4ca9732c603e8dc5e60784558c1c6dc047f876733"
+checksum = "6b3a87b44e34d17161e4f17d92a463d596cb13825dcd1758ed18fd3a721e189c"
 dependencies = [
  "cc",
  "glob",
+ "pkg-config",
 ]
 
 [[package]]
@@ -1026,6 +1033,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "png"
@@ -1302,6 +1315,9 @@ name = "rgb"
 version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "rustix"
@@ -1652,13 +1668,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8225fa9cacbdd3c0eccaf5cab3f1920b70b02447ff67b4af1ca15873d2fa445f"
 
 [[package]]
-name = "webp"
-version = "0.3.1"
+name = "webpx"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c071456adef4aca59bf6a583c46b90ff5eb0b4f758fc347cea81290288f37ce1"
+checksum = "a261d6edef9c7f7e4b6d30bdf52313d53b9868b2df4638e27e9fe17368220775"
 dependencies = [
- "image",
+ "enough",
+ "imgref",
  "libwebp-sys",
+ "rgb",
+ "whereat",
 ]
 
 [[package]]
@@ -1666,6 +1685,12 @@ name = "weezl"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
+name = "whereat"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab90f361db038ba3135da12c938c328fb43a012992101879e3d6ebccb4d7eba8"
 
 [[package]]
 name = "windows-link"
@@ -1793,7 +1818,7 @@ dependencies = [
  "quickcheck_macros",
  "strum",
  "tempfile",
- "webp",
+ "webpx",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ image = { version = "0.25.9", default-features = false, features = ["rayon"] }
 pic-scale-safe = { version = "0.1.5", features = ["rayon"] }
 strum = { version = "0.26.3", features = ["derive"] }
 tempfile = "3.23.0"
-webp = "0.3.1"
+webpx = { version = "0.3.3", default-features = false, optional = true, features = ["encode", "std", "icc"] }
 mimalloc = { version = "0.1.47", optional = true }
 jxl-oxide = { version = "0.12.5", features = ["image", "moxcms"], optional = true }
 hayro-jpeg2000 = { version = "0.3.0", optional = true }
@@ -50,7 +50,7 @@ sgi = ["image-extras/sgi"]
 tga = ["image/tga"]
 tiff = ["image/tiff"]
 wbmp = ["image-extras/wbmp"]
-webp = ["image/webp"]
+webp = ["image/webp", "webpx"]
 xbm = ["image-extras/xbm"]
 xpm = ["image-extras/xpm"]
 

--- a/src/encoders/webp.rs
+++ b/src/encoders/webp.rs
@@ -2,7 +2,8 @@ use std::io::Write;
 
 use crate::encoders::common::to_8bit_rgb_maybe_a;
 use crate::{error::MagickError, image::Image, plan::Modifiers, wm_err, wm_try};
-use webp::{Encoder, WebPMemory};
+use image::DynamicImage;
+use webpx::{EncoderConfig, Unstoppable};
 
 pub fn encode<W: Write>(
     image: &Image,
@@ -11,18 +12,75 @@ pub fn encode<W: Write>(
 ) -> Result<(), MagickError> {
     // Convert the image to Rgb(a)8, because those are the only formats the encoder supports
     let pixels = to_8bit_rgb_maybe_a(&image.pixels);
-    let encoder: Encoder = Encoder::from_image(pixels.as_ref()).unwrap();
     // imagemagick signals that the image should be lossless with quality=100
     let lossless = modifiers.quality == Some(100.0);
     // default quality is not documented, was determined experimentally
     let quality = modifiers.quality.unwrap_or(75.0) as f32;
 
-    // Encode the image with the specified quality
-    let webp: WebPMemory = encoder
-        .encode_simple(lossless, quality)
-        .map_err(|e| wm_err!("WebP encoding failed: {e:?}"))?;
-    // TODO: `webp` crate doesn't support setting the ICC profile:
-    // https://github.com/jaredforth/webp/issues/41
+    let mut config = EncoderConfig::new().quality(quality).lossless(lossless);
+    if let Some(icc) = image.icc.clone() {
+        config = config.icc_profile(icc);
+    }
+    if let Some(exif) = image.exif.clone() {
+        config = config.exif(exif);
+    }
+    if let Some(xmp) = image.xmp.clone() {
+        config = config.xmp(xmp);
+    }
+
+    let webp = match pixels.as_ref() {
+        DynamicImage::ImageRgb8(pixels) => config.encode_rgb(
+            pixels.as_raw(),
+            pixels.width(),
+            pixels.height(),
+            Unstoppable,
+        ),
+        DynamicImage::ImageRgba8(pixels) => config.encode_rgba(
+            pixels.as_raw(),
+            pixels.width(),
+            pixels.height(),
+            Unstoppable,
+        ),
+        _ => unreachable!("to_8bit_rgb_maybe_a only returns Rgb8 or Rgba8"),
+    }
+    .map_err(|e| wm_err!("WebP encoding failed: {e:?}"))?;
+
     wm_try!(writer.write_all(&webp));
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::image::InputProperties;
+    use image::{ExtendedColorType, ImageFormat};
+
+    fn image_with_metadata() -> Image {
+        Image {
+            format: Some(ImageFormat::WebP),
+            exif: Some(vec![1, 2, 3]),
+            xmp: Some(
+                br#"<x:xmpmeta xmlns:x="adobe:ns:meta/"><rdf:RDF></rdf:RDF></x:xmpmeta>"#.to_vec(),
+            ),
+            icc: Some(vec![4, 5, 6]),
+            pixels: DynamicImage::new_rgba8(2, 2),
+            properties: InputProperties {
+                filename: "input.webp".into(),
+                color_type: ExtendedColorType::Rgba8,
+            },
+        }
+    }
+
+    #[test]
+    fn embeds_metadata() {
+        let image = image_with_metadata();
+        let mut output = Vec::new();
+
+        encode(&image, &mut output, &Modifiers::default()).unwrap();
+
+        assert_eq!(webpx::get_exif(&output).unwrap(), image.exif);
+        assert_eq!(webpx::get_xmp(&output).unwrap(), image.xmp);
+        assert_eq!(webpx::get_icc_profile(&output).unwrap(), image.icc);
+    }
 }


### PR DESCRIPTION
My audits have uncovered soundness issues in both `webp` and `webpx` but only `webpx` has fixed them quickly. `webpx` also allows us to write Exif/XMP/ICC metadata which is a must.

It would be much better to use a pure-Rust implementation, but:

 - image-webp encoding support is still immature
 - zenwebp is under AGPL license which is too restrictive for our use
 - oxideav-webp is impractically slow, see #93